### PR TITLE
Change Linux pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can install garmin-uploader as any othe package availale on PyPi with pip:
 
 On Linux
 ```
-sudo pip install garmin-uploader
+pip install garmin-uploader --user
 ```
 
 On Windows


### PR DESCRIPTION
Update Linux pip install section to use `--user` instead of `sudo` per industry recommendations.
https://developers.redhat.com/blog/2018/08/13/install-python3-rhel/
https://dev.to/elabftw/stop-using-sudo-pip-install-52mn