### PR TITLE
Use Cloudscraper, change login path, and retry user authentication

### DIFF
--- a/garmin_uploader/api.py
+++ b/garmin_uploader/api.py
@@ -1,10 +1,11 @@
 import requests
+import cloudscraper
 
 import re
 from garmin_uploader import logger
 
 URL_HOSTNAME = 'https://connect.garmin.com/modern/auth/hostname'
-URL_LOGIN = 'https://sso.garmin.com/sso/login'
+URL_LOGIN = 'https://sso.garmin.com/sso/signin'
 URL_POST_LOGIN = 'https://connect.garmin.com/modern/'
 URL_PROFILE = 'https://connect.garmin.com/modern/currentuser-service/user/info'  # noqa
 URL_HOST_SSO = 'sso.garmin.com'
@@ -41,10 +42,7 @@ class GarminAPI:
         """
         # Use a valid Browser user agent
         # TODO: use several UA picked randomly
-        session = requests.Session()
-        session.headers.update({
-            'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:48.0) Gecko/20100101 Firefox/50.0',  # noqa
-        })
+        session = cloudscraper.create_scraper()
 
         # Request sso hostname
         sso_hostname = None

--- a/garmin_uploader/user.py
+++ b/garmin_uploader/user.py
@@ -62,8 +62,8 @@ class User(object):
         Authenticate on Garmin API
         """
         if self.session is not None and not force:
-            # return the cached session unless we are forcing authentication
-            # this will help with tests so we don't constantly try to reauthenticate
+            # return cached session unless we're forcing authentication this
+            # will help keep test from constantly trying to reauthenticate
             return self.session
         logger.info('Try to login on GarminConnect...')
         logger.debug('Username: {}'.format(self.username))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.10.0
 six>=1.10.0
+cloudscraper==1.2.58

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.10.0
 six>=1.10.0
-cloudscraper==1.2.58
+cloudscraper==1.2.46


### PR DESCRIPTION
This commit fixes authentication for July 2022, the login path had changed, and cloudscraper was still needed.

I also noticed that authentication was still intermittent, so I added a few retries, and returning the cached session so that tests don't try a lot of sign-in requests